### PR TITLE
Snap-to behavior

### DIFF
--- a/ionic.headerShrink.js
+++ b/ionic.headerShrink.js
@@ -36,6 +36,9 @@ angular.module('ionic.ion.headerShrink', [])
 
         if(scrollTop >= 0) {
           y = Math.min(headerHeight / scrollDelay, Math.max(0, y + scrollTop - prevY));
+          if( y*1.02 > headerHeight ){
+            y = headerHeight
+          }
         } else {
           y = 0;
         }


### PR DESCRIPTION
This change snaps the header to a pixel-perfect hide when the menu gets to within 99% of full-hidden position. This compensates for scroll sampling lag.
